### PR TITLE
Don't call setpgid() if we are already the process group leader.

### DIFF
--- a/owampd/owampd.c
+++ b/owampd/owampd.c
@@ -1673,7 +1673,7 @@ int main(
          * kill call.) setsid handles this when daemonizing.
          */
         mypid = getpid();
-        if(setpgid(0,mypid) != 0){
+        if(getsid(0) != mypid && setpgid(0,mypid) != 0){
             I2ErrLog(errhand,"setpgid(): %M");
             exit(1);
         }


### PR DESCRIPTION
This allows owampd -Z to run under OSX launchd with a plist file.

For full details see [the same issue](https://github.com/perfsonar/bwctl/issues/10) with bwctld.

(Unfortunately the original patch got mangled in the migration from google code to github, but it's just a one-liner)