### PR TITLE
Fix invalid struct timeval values (affects OSX)

### DIFF
--- a/owamp/endpoint.c
+++ b/owamp/endpoint.c
@@ -2188,6 +2188,11 @@ again:
         timespecsub((struct timespec*)&wake.it_value,&currtime);
 
         wake.it_value.tv_usec /= 1000;        /* convert nsec to usec        */
+        while (wake.it_value.tv_usec >= 1000000) {
+            wake.it_value.tv_usec -= 1000000;
+            wake.it_value.tv_sec++;
+        }
+
         tvalclear(&wake.it_interval);
 
         /*


### PR DESCRIPTION
Patch provided by Aaron Brown at:
<https://lists.internet2.edu/sympa/arc/perfsonar-user/2014-11/msg00131.html>

This fix is known to work, and is currently included as an ad-hoc patch in [homebrew](https://github.com/Homebrew/homebrew-core/blob/master/Formula/owamp.rb#L36), but it would be better to be integrated upstream.