### PR TITLE
twamp: ignore client's port offer if outside of server testports range

### DIFF
--- a/owamp/endpoint.c
+++ b/owamp/endpoint.c
@@ -504,6 +504,16 @@ _OWPEndpointInit(
 
     portrange = (OWPPortRange)OWPContextConfigGetV(cntrl->ctx, OWPTestPortRange);
 
+    /*
+     * If the requested TWAMP port is not within the testports range,
+     * ignore it and use a random port instead.
+     */
+    if(cntrl->twoway && cntrl->server && port && portrange){
+        if(port < portrange->low || port > portrange->high){
+            port = 0;
+        }
+    }
+
     if(port){
         /*
          * port specified by saddr


### PR DESCRIPTION
If the twamp-server always accepts the client suggested port number
it might end up binding to a port outside of testport range as defined
in the config file.  Ports outside of this range might be blocked by
an external firewall and cause twamp test packets to be blocked.