### PR TITLE
Cleanup 12 bytes after the IPv4 address in Request-Session packet

### DIFF
--- a/owamp/protocol.c
+++ b/owamp/protocol.c
@@ -694,11 +694,13 @@ _OWPEncodeTestRequestPreamble(
         saddr4 = (struct sockaddr_in*)sender;
         *(uint32_t*)&buf[16] = saddr4->sin_addr.s_addr;
         *(uint16_t*)&buf[12] = saddr4->sin_port;
+        memset(&buf[20],0,12);
 
         /* receiver address and port  */
         saddr4 = (struct sockaddr_in*)receiver;
         *(uint32_t*)&buf[32] = saddr4->sin_addr.s_addr;
         *(uint16_t*)&buf[14] = saddr4->sin_port;
+        memset(&buf[36],0,12);
 
         break;
         default:


### PR DESCRIPTION
These additional bytes are there to support IPv6 addresses,
but end up with some memory garbage if not zeroed explicitly.

This seems to cause problem with some TWAMP servers implementations (i.e. Juniper).