### PR TITLE
Add SO_BINDTODEVICE options for owping/twping/powstream

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,5 +1,4 @@
 Check datadir is writable on startup: fail if not
-option to SO_BINDTODEVICE
 Modify to treat I2util as independent package
 Fix version string in help message (Now reports I2util version)
 Document missing packet format for -R output

--- a/configure.ac
+++ b/configure.ac
@@ -94,6 +94,9 @@ OWPINCS='-I${top_srcdir}'
 
 OWP_dir='${top_srcdir}/owamp'
 OWPLDFLAGS="-L$OWP_dir"
+
+AC_CHECK_LIB([cap], [cap_set_proc])
+
 OWPLIBS="$OWPLDFLAGS -lowamp"
 OWPLIBDEPS="$OWP_dir/libowamp.a"
 

--- a/doc/owping_conn_opts.man
+++ b/doc/owping_conn_opts.man
@@ -91,6 +91,15 @@ the IP addresses. (IPv6 addresses are of course supported.)
 Unspecified (wild-card address selection).
 .RE
 .TP
+\fB\-B\fR \fIinterface\fR
+.br
+Bind the client sockets to the network interface \fIinterface\fR with
+SO_BINDTODEVICE.
+.RS
+.IP Default:
+Unspecified (sockets not bound to a particular interface).
+.RE
+.TP
 \fB\-u\fR \fIusername\fR
 .br
 Specify the username that identifies the shared secret (pass-phrase)

--- a/doc/powstream.man
+++ b/doc/powstream.man
@@ -314,6 +314,15 @@ the IP addresses. (IPv6 addresses are, of course, supported.)
 Unspecified (wild-card address selection)
 .RE
 .TP
+\fB\-B\fR \fIinterface\fR
+.br
+Bind the client sockets to the network interface \fIinterface\fR with
+SO_BINDTODEVICE.
+.RS
+.IP Default:
+Unspecified (sockets not bound to a particular interface).
+.RE
+.TP
 \fB\-u\fR \fIusername\fR
 .br
 Specify the username that is used to identify the shared secret (pass-phrase)

--- a/owamp/api.c
+++ b/owamp/api.c
@@ -32,6 +32,10 @@
 #include <libgen.h>
 #include <poll.h>
 
+#ifdef HAVE_LIBCAP
+#include <sys/capability.h>
+#endif
+
 
 /*
  * Function:        OWPGetContext
@@ -3750,6 +3754,119 @@ OWPControlIsTwoWay(
     return cntrl->twoway;
 }
 
+#ifdef HAVE_LIBCAP
+
+/*
+ * Function:        OWPSetEffectiveCapability
+ *
+ * Description:
+ *         Performs an operation on the specified capability within the
+ *         process' effective capability set.
+ *
+ * In Args:
+ *
+ * Out Args:
+ *
+ * Scope:
+ * Returns:
+ * Side Effect:
+ */
+static OWPBoolean
+OWPSetEffectiveCapability(
+        OWPContext          ctx,
+        char                *capability_name,
+        cap_flag_value_t    operation
+        )
+{
+    cap_t capabilities = NULL;
+    cap_value_t capability;
+    OWPBoolean ret = False;
+
+    assert(capability_name);
+
+    if(cap_from_name(capability_name, &capability) == -1){
+        OWPError(ctx, OWPErrFATAL, OWPErrUNKNOWN,
+                 "Unknown capability: %s", capability_name);
+        return False;
+    }
+
+    if(!(capabilities = cap_get_proc())){
+        OWPError(ctx, OWPErrWARNING, errno,
+                 "Could not get process capabilities: %M");
+        return False;
+    }
+
+    if(cap_set_flag(capabilities, CAP_EFFECTIVE, 1, &capability, operation)){
+        OWPError(ctx, OWPErrWARNING, errno,
+                 "Could not %s capability %s in the CAP_EFFECTIVE set: %M",
+                 operation == CAP_SET ? "set" : "clear", capability_name);
+        goto finish;
+    }
+
+    if(cap_set_proc(capabilities)){
+        OWPError(ctx, OWPErrWARNING, errno,
+                 "Could not %s capability %s: %M",
+                 operation == CAP_SET ? "add" : "remove", capability_name);
+        goto finish;
+    }
+
+    ret = True;
+finish:
+    if(cap_free(capabilities)){
+        OWPError(ctx, OWPErrWARNING, errno, "Capability free failure: %M");
+        ret = False;
+    }
+
+    return ret;
+}
+
+/*
+ * Function:        OWPAddEffectiveCapability
+ *
+ * Description:
+ *         Adds the specified capability to the process' effective set.
+ *
+ * In Args:
+ *
+ * Out Args:
+ *
+ * Scope:
+ * Returns:
+ * Side Effect:
+ */
+OWPBoolean
+OWPAddEffectiveCapability(
+        OWPContext  ctx,
+        char *capability_name
+    )
+{
+    return OWPSetEffectiveCapability(ctx, capability_name, CAP_SET);
+}
+
+/*
+ * Function:        OWPRemoveEffectiveCapability
+ *
+ * Description:
+ *         Removes the specified capability from the process' effective set.
+ *
+ * In Args:
+ *
+ * Out Args:
+ *
+ * Scope:
+ * Returns:
+ * Side Effect:
+ */
+OWPBoolean
+OWPRemoveEffectiveCapability(
+        OWPContext  ctx,
+        char *capability_name
+    )
+{
+    return OWPSetEffectiveCapability(ctx, capability_name, CAP_CLEAR);
+}
+#endif /* HAVE_LIBCAP */
+
 /*
  * Function:        OWPSocketInterfaceBind
  *
@@ -3772,13 +3889,25 @@ OWPSocketInterfaceBind(
     const char      *interface
     )
 {
+    int rc;
     assert(interface);
 
-    if(setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE,
-                  interface, strlen(interface))){
+#ifdef HAVE_LIBCAP
+    OWPAddEffectiveCapability(cntrl->ctx, "cap_net_raw");
+#endif
+
+    rc = setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE,
+                    interface, strlen(interface));
+
+#ifdef HAVE_LIBCAP
+    OWPRemoveEffectiveCapability(cntrl->ctx, "cap_net_raw");
+#endif
+
+    if(rc != 0){
         OWPError(cntrl->ctx, OWPErrFATAL, errno,
                  "SO_BINDTODEVICE %s: %M", interface);
         return False;
     }
+
     return True;
 }

--- a/owamp/api.c
+++ b/owamp/api.c
@@ -3749,3 +3749,36 @@ OWPControlIsTwoWay(
 {
     return cntrl->twoway;
 }
+
+/*
+ * Function:        OWPSocketInterfaceBind
+ *
+ * Description:
+ *         Bind the specified socket to the specified interface using
+ *         SO_BINDTODEVICE.
+ *
+ * In Args:
+ *
+ * Out Args:
+ *
+ * Scope:
+ * Returns:
+ * Side Effect:
+ */
+OWPBoolean
+OWPSocketInterfaceBind(
+    OWPControl      cntrl,
+    int             fd,
+    const char      *interface
+    )
+{
+    assert(interface);
+
+    if(setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE,
+                  interface, strlen(interface))){
+        OWPError(cntrl->ctx, OWPErrFATAL, errno,
+                 "SO_BINDTODEVICE %s: %M", interface);
+        return False;
+    }
+    return True;
+}

--- a/owamp/context.c
+++ b/owamp/context.c
@@ -326,6 +326,8 @@ OWPControlClose(
     I2AddrFree(cntrl->remote_addr);
     I2AddrFree(cntrl->local_addr);
 
+    free(cntrl->interface);
+
     free(cntrl);
 
     return err;

--- a/owamp/endpoint.c
+++ b/owamp/endpoint.c
@@ -475,6 +475,10 @@ _OWPEndpointInit(
         goto error;
     }
 
+    if(cntrl->interface &&
+       !OWPSocketInterfaceBind(cntrl, ep->sockfd, cntrl->interface))
+        goto error;
+
     /*
      * Determine what port to try:
      */

--- a/owamp/owamp.h
+++ b/owamp/owamp.h
@@ -865,6 +865,21 @@ OWPControlOpen(
         );
 
 /*
+ * Identical to OWPControlOpen but binds to the specified interface.
+ */
+extern OWPControl
+OWPControlOpenInterface(
+        OWPContext      ctx,            /* control context                */
+        const char      *local_addr,    /* local addr or null             */
+        const char      *interface,     /* interface to bind to or NULL   */
+        I2Addr          server_addr,    /* server addr                    */
+        uint32_t        mode_req_mask,  /* requested modes                */
+        OWPUserID       userid,         /* userid or NULL                 */
+        OWPNum64        *uptime_ret,    /* server uptime - ret            */
+        OWPErrSeverity  *err_ret        /* err - return                   */
+        );
+
+/*
  * TWPControlOpen is similar to OWPControlOpen, except that it
  * connects to a TWP server
  */
@@ -874,6 +889,21 @@ TWPControlOpen(
         const char      *local_addr,    /* src addr or NULL             */
         I2Addr          server_addr,    /* server addr or NULL          */
         uint32_t       mode_mask,      /* OR of OWPSessionMode vals    */
+        OWPUserID       userid,         /* null if unwanted             */
+        OWPNum64        *uptime_ret,    /* server uptime - ret or NULL  */
+        OWPErrSeverity  *err_ret
+        );
+
+/*
+ * Identical to TWPControlOpen but binds to the specified interface.
+ */
+extern OWPControl
+TWPControlOpenInterface(
+        OWPContext      ctx,
+        const char      *local_addr,    /* src addr or NULL             */
+        const char      *interface,     /* interface to bind to or NULL */
+        I2Addr          server_addr,    /* server addr or NULL          */
+        uint32_t        mode_mask,      /* OR of OWPSessionMode vals    */
         OWPUserID       userid,         /* null if unwanted             */
         OWPNum64        *uptime_ret,    /* server uptime - ret or NULL  */
         OWPErrSeverity  *err_ret

--- a/owamp/owampP.h
+++ b/owamp/owampP.h
@@ -249,6 +249,7 @@ struct OWPControlRec{
      */
     I2Addr                  remote_addr;
     I2Addr                  local_addr;
+    char                    *interface;
     int                     sockfd;
 
     /*
@@ -1022,5 +1023,12 @@ extern OWPBoolean
 _OWPIsInterface(
         const char *interface
         );
+
+extern OWPBoolean
+OWPSocketInterfaceBind(
+    OWPControl      cntrl,
+    int             fd,
+    const char      *interface
+);
 
 #endif        /* OWAMPP_H */

--- a/owping/owpingP.h
+++ b/owping/owpingP.h
@@ -81,6 +81,7 @@ typedef    struct {
         char            *savedir;           /* -d */
         I2Boolean       printfiles;         /* -p */
         char            *srcaddr;           /* -S */
+        char            *interface;         /* -B */
 
         OWPPortRange    portspec;           /* -P */
 

--- a/powstream/powstream.c
+++ b/powstream/powstream.c
@@ -39,6 +39,7 @@
 #include <assert.h>
 #include <syslog.h>
 #include <math.h>
+#include <net/if.h>
 
 
 #if defined HAVE_DECL_OPTRESET && !HAVE_DECL_OPTRESET
@@ -110,6 +111,7 @@ print_conn_args(){
 "   -A authmode    requested modes: [A]uthenticated, [E]ncrypted, [O]pen\n"
 "   -k pffile      pass-phrase file to use with Authenticated/Encrypted modes\n"
 "   -S srcaddr     specify the local address or interface for control connection and tests\n"
+"   -B interface   specify the interface to use for control connection and tests",
 "   -u username    username to use with Authenticated/Encrypted modes\n"
 "   -I retryDelay  time to wait between failed connections (default: 60 seconds)\n"
         );
@@ -385,8 +387,9 @@ FetchSession(
     uint32_t       num_rec;
 
     if (p->fetch == NULL) {
-        p->fetch = OWPControlOpen(p->ctx,
+        p->fetch = OWPControlOpenInterface(p->ctx,
                         appctx.opt.srcaddr,
+                        appctx.opt.interface,
                         I2AddrByNode(eh, appctx.remote_serv),
                         appctx.auth_mode,appctx.opt.identity,
                         NULL,&err);
@@ -1043,8 +1046,9 @@ SetupSession(
     }
 
 
-    if(!(p->cntrl = OWPControlOpen(ctx,
+    if(!(p->cntrl = OWPControlOpenInterface(ctx,
                     appctx.opt.srcaddr,
+                    appctx.opt.interface,
                     I2AddrByNode(eh, appctx.remote_serv),
                     appctx.auth_mode,appctx.opt.identity,
                     NULL,&err))){
@@ -1263,7 +1267,7 @@ main(
     int                 ch;
     char                *endptr = NULL;
     char                optstring[128];
-    static char         *conn_opts = "46A:k:S:u:I:";
+    static char         *conn_opts = "46A:k:S:B:u:I:";
     static char         *test_opts = "c:E:i:L:s:tz:P:";
     static char         *out_opts = "b:d:e:g:N:pRvU";
     static char         *gen_opts = "hw";
@@ -1443,6 +1447,16 @@ main(
                 break;
             case 'S':
                 if (!(appctx.opt.srcaddr = strdup(optarg))) {
+                    I2ErrLog(eh,"malloc: %M");
+                    exit(1);
+                }
+                break;
+            case 'B':
+                if(appctx.opt.interface){
+                    usage(progname,"-B can only be used once");
+                    exit(1);
+                }
+                if(!(appctx.opt.interface = strndup(optarg, IFNAMSIZ))){
                     I2ErrLog(eh,"malloc: %M");
                     exit(1);
                 }

--- a/powstream/powstreamP.h
+++ b/powstream/powstreamP.h
@@ -66,6 +66,7 @@ typedef        struct {
         OWPBoolean  v6only;             /* -6 */
 
         char        *srcaddr;           /* -S */
+        char        *interface;         /* -B */
         char        *authmode;          /* -A */
         char        *identity;          /* -u */
         char        *pffile;            /* -k */


### PR DESCRIPTION
Here is some example usage of the SO_BINDTODEVICE options. Here we use them for OWAMP/TWAMP operations in a VRF, by binding to the VRF master interface:

Environment:
```
# No route to 10.10.1.2 in the default VRF
$ ip route get 10.10.1.2
RTNETLINK answers: Network is unreachable

$ ip route get vrf vrfblue 10.10.1.2
10.10.1.2 dev ens8 table 256 src 10.10.1.1 uid 1000 
    cache

$ sudo getcap owping twping powstream
owping = cap_net_raw+p
twping = cap_net_raw+p
powstream = cap_net_raw+p
```
`owping`:
```
$ ./owping -c 10 10.10.1.2
owping: FILE=time.c, LINE=112, NTP: Status UNSYNC (clock offset issues likely)
owping: FILE=time.c, LINE=118, NTP: STA_NANO should be set. Make sure ntpd is running, and your NTP configuration is good.
owping: FILE=owping.c, LINE=1742, Unable to open control connection to 10.10.1.2.
$ 
$ ./owping -I vrfblue -c 10 10.10.1.2
owping: FILE=time.c, LINE=112, NTP: Status UNSYNC (clock offset issues likely)
owping: FILE=time.c, LINE=118, NTP: STA_NANO should be set. Make sure ntpd is running, and your NTP configuration is good.
Approximately 3.9 seconds until results available

--- owping statistics from [10.10.1.1]:9068 to [10.10.1.2]:9855 ---
SID:	0a0a0102dfafeec69400da1ab179ccc7
first:	2018-12-03T18:04:55.098
last:	2018-12-03T18:04:55.732
10 sent, 0 lost (0.000%), 0 duplicates
one-way delay min/median/max = 473/473/473 ms, (unsync)
one-way jitter = 0.3 ms (P95-P50)
hops = 0 (consistently)
no reordering


--- owping statistics from [10.10.1.2]:9093 to [10.10.1.1]:9777 ---
SID:	0a0a0101dfafeec61b837b4ad9897b67
first:	2018-12-03T18:04:55.103
last:	2018-12-03T18:04:55.857
10 sent, 0 lost (0.000%), 0 duplicates
one-way delay min/median/max = -472/-472/-471 ms, (unsync)
one-way jitter = 0.4 ms (P95-P50)
hops = 0 (consistently)
no reordering
```
`twping`:
```
$ ./twping -c 10 10.10.1.2
twping: FILE=time.c, LINE=112, NTP: Status UNSYNC (clock offset issues likely)
twping: FILE=time.c, LINE=118, NTP: STA_NANO should be set. Make sure ntpd is running, and your NTP configuration is good.
twping: FILE=owping.c, LINE=1742, Unable to open control connection to 10.10.1.2.
$ 
$ ./twping -I vrfblue -c 10 10.10.1.2
twping: FILE=time.c, LINE=112, NTP: Status UNSYNC (clock offset issues likely)
twping: FILE=time.c, LINE=118, NTP: STA_NANO should be set. Make sure ntpd is running, and your NTP configuration is good.
Approximately 4.0 seconds until results available

Directional delays may be inaccurate due to out of sync clocks!

--- twping statistics from [10.10.1.1]:8940 to [10.10.1.2]:8940 ---
SID:	0a0a0102dfafeef4d3d41743fdf78752
first:	2018-12-03T18:05:41.433
last:	2018-12-03T18:05:42.344
10 sent, 0 lost (0.000%), 0 send duplicates, 0 reflect duplicates
round-trip time min/median/max = 0.959/1.4/1.63 ms, (err=9.31e-07 ms)
send time min/median/max = 473/473/473 ms, (err=4.66e-07 ms)
reflect time min/median/max = -472/-472/-472 ms, (err=4.66e-07 ms)
reflector processing time min/max = 0.0148/0.0463 ms
two-way jitter = 0.3 ms (P95-P50)
send jitter = 0.3 ms (P95-P50)
reflect jitter = 0.1 ms (P95-P50)
send hops = 0 (consistently)
reflect hops = 0 (consistently)
```
`powstream`:
```
$ ./powstream -p -c 10 10.10.1.2
powstream[5065]: Warning: Holes in data are likely because lossThreshold(10) is too large a fraction of approx summary session duration(1)
powstream[5065]: NTP: Status UNSYNC (clock offset issues likely)
powstream[5065]: NTP: STA_NANO should be set. Make sure ntpd is running, and your NTP configuration is good.
powstream[5065]: OWPControlOpen(10.10.1.2): Couldn't open 'control' connection to server: Network is unreachable
powstream[5065]: OWPControlOpen(10.10.1.2): Couldn't open 'control' connection to server: Network is unreachable
powstream[5065]: OWPControlOpen(10.10.1.2): Waiting 0.998966000 seconds before retrying
powstream[5065]: OWPControlOpen(10.10.1.2): Couldn't open 'control' connection to server: Network is unreachable
powstream[5065]: OWPControlOpen(10.10.1.2): Waiting 0.567000 seconds before retrying
powstream[5065]: OWPControlOpen(10.10.1.2): Couldn't open 'control' connection to server: Network is unreachable
powstream[5065]: OWPControlOpen(10.10.1.2): Waiting 0.996774999 seconds before retrying
^Cpowstream[5065]: SIGTERM/SIGINT Caught: Exiting.
$ 
$ ./powstream -p -T vrfblue -c 10 10.10.1.2
powstream[5066]: Warning: Holes in data are likely because lossThreshold(10) is too large a fraction of approx summary session duration(1)
powstream[5066]: NTP: Status UNSYNC (clock offset issues likely)
powstream[5066]: NTP: STA_NANO should be set. Make sure ntpd is running, and your NTP configuration is good.
16118365018432400441_16118365022600702779.owp
16118365018432400441_16118365022600702779.sum
16118365022600702779_16118365027207155936.owp
16118365022600702779_16118365027207155936.sum
^Cpowstream[5066]: SIGTERM/SIGINT Caught: Exiting.
$ ./owstats 16118365018432400441_16118365022600702779.owp
owstats: FILE=time.c, LINE=112, NTP: Status UNSYNC (clock offset issues likely)
owstats: FILE=time.c, LINE=118, NTP: STA_NANO should be set. Make sure ntpd is running, and your NTP configuration is good.

--- owping statistics from [10.10.1.2]:9323 to [10.10.1.1]:9244 ---
SID:	0a0a0101dfafef8be46a3bdd2038d18f
first:	2018-12-03T18:08:21.896
last:	2018-12-03T18:08:22.860
10 sent, 0 lost (0.000%), 0 duplicates
one-way delay min/median/max = -472/-472/-471 ms, (unsync)
one-way jitter = 0.3 ms (P95-P50)
hops = 0 (consistently)
no reordering
```
Example of a bind failure:
```
$ ./owping -I vrfblue -c 10 10.10.1.2
owping: FILE=time.c, LINE=112, NTP: Status UNSYNC (clock offset issues likely)
owping: FILE=time.c, LINE=118, NTP: STA_NANO should be set. Make sure ntpd is running, and your NTP configuration is good.
owping: FILE=api.c, LINE=3807, Could not add capability cap_net_raw: Operation not permitted
owping: FILE=api.c, LINE=3907, SO_BINDTODEVICE vrfblue: Operation not permitted
owping: FILE=owping.c, LINE=1738, Unable to open control connection to 10.10.1.2.
```