### PR TITLE
Reduce rDNS lookups

### DIFF
--- a/owamp/capi.c
+++ b/owamp/capi.c
@@ -259,6 +259,8 @@ _OWPClientConnect(
     struct addrinfo *ai=NULL;
     char            *serv;
 #ifdef NOT
+    struct sockaddr *servaddr;
+    socklen_t       servaddrlen;
     char            nodename[NI_MAXHOST];
     size_t          nodename_len = sizeof(nodename);
     char            servname[NI_MAXSERV];
@@ -335,17 +337,18 @@ error:
      * Unable to connect! If we have a server name report it in
      * the error message.
      */
-    if(I2AddrNodeName(server_addr,nodename,&nodename_len)){
-        node = nodename;
-    }
-    else
+    serveraddr = I2AddrSAddr(server_addr, &serveraddrlen);
+    if(!serveraddr || getnameinfo(serveraddr, serveraddrlen,
+                        nodename, nodename_len,
+                        servname, servname_len,
+                        NI_NUMERICSERV | NI_NUMERICHOST) != 0){
         node = "**unknown**";
-
-    if(I2AddrServName(server_addr,servname,&servname_len)){
+        serv = OWP_CONTROL_SERVICE_NAME;
+    }
+    else{
+        node = nodename;
         serv = servname;
     }
-    else
-        serv = OWP_CONTROL_SERVICE_NAME;
 
     OWPError(cntrl->ctx,OWPErrFATAL,OWPErrUNKNOWN,
             "Unable to connect to \"[%s]:%s\"",node,serv);
@@ -604,12 +607,20 @@ OWPControlOpenCommon(
      * TODO: enumerate reason for rejection
      */
     if(acceptval != OWP_CNTRL_ACCEPT){
-        char nodename_buf[255];
+        char nodename_buf[NI_MAXHOST];
         size_t nodename_buflen;
+        struct sockaddr *serveraddr;
+        socklen_t serveraddrlen;
 
         nodename_buflen = sizeof(nodename_buf);
+        serveraddr = I2AddrSAddr(server_addr, &serveraddrlen);
+        if(!serveraddr || getnameinfo(serveraddr, serveraddrlen, nodename_buf,
+                            nodename_buflen, NULL, 0, NI_NUMERICHOST) != 0){
+            sprintf(nodename_buf, "unknown");
+        }
+
         OWPError(cntrl->ctx,OWPErrWARNING,OWPErrPOLICY,
-                "Server denied access: %s", I2AddrNodeName(server_addr, nodename_buf, &nodename_buflen));
+                "Server denied access: %s", nodename_buf);
         goto denied;
     }
 
@@ -740,8 +751,10 @@ _OWPClientRequestTestReadResponse(
     OWPAcceptType   acceptval;
     uint16_t        port_ret=0;
     uint8_t         *sid_ret=NULL;
-    char            nodename_buf[255];
+    char            nodename_buf[NI_MAXHOST];
     size_t          nodename_buflen;
+    struct sockaddr *remoteaddr;
+    socklen_t       remoteaddrlen;
 
     /*
      * For two way tests if a receiver port number has not been set then
@@ -793,7 +806,13 @@ _OWPClientRequestTestReadResponse(
      * TODO: enumerate failure reasons
      */
     nodename_buflen = sizeof(nodename_buf);
-    OWPError(cntrl->ctx,OWPErrWARNING,OWPErrPOLICY, "Server denied test: %s", I2AddrNodeName(cntrl->remote_addr, nodename_buf, &nodename_buflen));
+    remoteaddr = I2AddrSAddr(cntrl->remote_addr, &remoteaddrlen);
+    if(!remoteaddr || getnameinfo(remoteaddr, remoteaddrlen, nodename_buf,
+                        nodename_buflen, NULL, 0, NI_NUMERICHOST) != 0){
+        sprintf(nodename_buf, "unknown");
+    }
+    OWPError(cntrl->ctx,OWPErrWARNING,OWPErrPOLICY, "Server denied test: %s",
+                nodename_buf);
 
     *err_ret = OWPErrOK;
     return 1;

--- a/owamp/endpoint.c
+++ b/owamp/endpoint.c
@@ -406,9 +406,16 @@ _OWPEndpointInit(
     *err_ret = OWPErrFATAL;
     *aval = OWP_CNTRL_UNAVAILABLE_TEMP;
 
-    if( !I2AddrNodeName(localaddr,localnode,&localnodelen)){
+    if( !(saddr = I2AddrSAddr(localaddr,&saddrlen))){
         OWPError(cntrl->ctx,OWPErrFATAL,OWPErrUNKNOWN,
-                "I2AddrNodeName(): failed for localaddr");
+                "_EndpointInit: Unable to get saddr information");
+        return False;
+    }
+
+    if(getnameinfo(saddr, saddrlen, localnode, localnodelen, NULL, 0,
+            NI_NUMERICHOST) != 0){
+        OWPError(cntrl->ctx,OWPErrFATAL,OWPErrUNKNOWN,
+                "getnameinfo(): failed for localaddr");
         return False;
     }
 
@@ -420,12 +427,6 @@ _OWPEndpointInit(
 
     ep->tsession = tsession;
     ep->cntrl = cntrl;
-
-    if( !(saddr = I2AddrSAddr(localaddr,&saddrlen))){
-        OWPError(cntrl->ctx,OWPErrFATAL,OWPErrUNKNOWN,
-                "_EndpointInit: Unable to get saddr information");
-        goto error;
-    }
 
     if (cntrl->twoway) {
         tpsize = OWPTestTWPacketSize(saddr->sa_family,
@@ -1299,8 +1300,9 @@ run_sender(
     int             r;
 
     if( !(saddr = I2AddrSAddr(ep->remoteaddr,&saddrlen)) ||
-                !I2AddrNodeName(ep->remoteaddr,nodename,&nodenamelen) ||
-                !I2AddrServName(ep->remoteaddr,nodeserv,&nodeservlen)){
+                (getnameinfo(saddr, saddrlen, nodename, nodenamelen,
+                        nodeserv, nodeservlen,
+                        NI_NUMERICHOST | NI_NUMERICHOST) != 0)){
             OWPError(ep->cntrl->ctx,OWPErrFATAL,OWPErrUNKNOWN,
                     "run_sender: Unable to extract saddr information");
             exit(OWP_CNTRL_FAILURE);
@@ -3137,8 +3139,9 @@ run_tw_test(
     }
 
     if( !(rsaddr = I2AddrSAddr(ep->remoteaddr,&rsaddrlen)) ||
-                !I2AddrNodeName(ep->remoteaddr,nodename,&nodenamelen) ||
-                !I2AddrServName(ep->remoteaddr,nodeserv,&nodeservlen)){
+                (getnameinfo(rsaddr, rsaddrlen, nodename, nodenamelen,
+                             nodeserv, nodeservlen,
+                             NI_NUMERICHOST | NI_NUMERICSERV) != 0)){
         OWPError(ep->cntrl->ctx,OWPErrFATAL,OWPErrUNKNOWN,
                  "run_tw_test: Unable to extract remote saddr information");
         exit(OWP_CNTRL_FAILURE);

--- a/owamp/stats.c
+++ b/owamp/stats.c
@@ -707,13 +707,14 @@ OWPStatsCreate(
         strcpy(stats->fromaddr,"***");
         stats->fromserv[0] = '\0';
     }
-    if( (getnameinfo((struct sockaddr*)&hdr->addr_sender,
+
+    if(fromhost){
+        strncpy(stats->fromhost,fromhost,NI_MAXHOST-1);
+    }
+    else if( (getnameinfo((struct sockaddr*)&hdr->addr_sender,
                 hdr->addr_len,stats->fromhost,NI_MAXHOST,
                 NULL,0,0) != 0)){
         strcpy(stats->fromhost,"***");
-    }
-    if(fromhost){
-        strncpy(stats->fromhost,fromhost,NI_MAXHOST-1);
     }
 
     if( (getnameinfo((struct sockaddr*)&hdr->addr_receiver,
@@ -724,13 +725,14 @@ OWPStatsCreate(
         strcpy(stats->toaddr,"***");
         stats->toserv[0] = '\0';
     }
-    if( (getnameinfo((struct sockaddr*)&hdr->addr_receiver,
+
+    if(tohost){
+        strncpy(stats->tohost,tohost,NI_MAXHOST-1);
+    }
+    else if( (getnameinfo((struct sockaddr*)&hdr->addr_receiver,
                 hdr->addr_len,stats->tohost,NI_MAXHOST,
                 NULL,0,0) != 0)){
         strcpy(stats->tohost,"***");
-    }
-    if(tohost){
-        strncpy(stats->tohost,tohost,NI_MAXHOST-1);
     }
 
     /*


### PR DESCRIPTION
In our usage we experienced significant delays when there were DNS problems, due to the use of reverse DNS lookups for printing host names in various log messages.

#4 