### PR TITLE
Send zero-addresses in twping request for simple NAT support

### DIFF
--- a/owamp/api.c
+++ b/owamp/api.c
@@ -2899,8 +2899,8 @@ OWPWriteDataHeader(
     if((_OWPEncodeTestRequestPreamble(ctx,msg,&len,
                     (struct sockaddr*)&hdr->addr_sender,
                     (struct sockaddr*)&hdr->addr_receiver,
-                    hdr->twoway?True:hdr->conf_sender,hdr->conf_receiver,False,
-                    hdr->sid,&hdr->test_spec) != 0) || !len){
+                    hdr->twoway?True:hdr->conf_sender,hdr->conf_receiver,
+                    False,False,hdr->sid,&hdr->test_spec) != 0) || !len){
         return False;
     }
     ver = htonl((hdr->twoway?_OWP_VERSION_TWOWAY:0)|3);

--- a/owamp/capi.c
+++ b/owamp/capi.c
@@ -731,6 +731,7 @@ _OWPClientRequestTestReadResponse(
         OWPBoolean      server_conf_sender,
         I2Addr          receiver,
         OWPBoolean      server_conf_receiver,
+        OWPBoolean      zero_addr,
         OWPTestSpec     *test_spec,
         OWPSID          sid,  /* ret iff cntrl->twoway || conf_receiver else set */
         OWPErrSeverity  *err_ret
@@ -756,7 +757,7 @@ _OWPClientRequestTestReadResponse(
     if( (rc = _OWPWriteTestRequest(cntrl,retn_on_intr,
                     I2AddrSAddr(sender,NULL),
                     I2AddrSAddr(receiver,NULL),
-                    server_conf_sender, server_conf_receiver,
+                    server_conf_sender, server_conf_receiver,zero_addr,
                     cntrl->twoway ? NULL : sid, test_spec)) < OWPErrOK){
         *err_ret = (OWPErrSeverity)rc;
         return 1;
@@ -823,6 +824,7 @@ OWPSessionRequest(
         OWPBoolean      server_conf_sender,
         I2Addr          receiver,
         OWPBoolean      server_conf_receiver,
+        OWPBoolean      zero_addr,
         OWPTestSpec     *test_spec,
         FILE            *fp,
         OWPSID          sid_ret,
@@ -1038,6 +1040,7 @@ foundaddr:
                         !cntrl->twoway && server_conf_sender,
                         receiver,
                         !cntrl->twoway && server_conf_receiver,
+                        zero_addr,
                         test_spec,tsession->sid,err_ret)) != 0){
             goto error;
         }
@@ -1120,6 +1123,7 @@ foundaddr:
             if((rc = _OWPClientRequestTestReadResponse(cntrl,retn_on_intr,
                             sender,server_conf_sender,
                             receiver,server_conf_receiver,
+                            zero_addr,
                             test_spec,tsession->sid,err_ret)) != 0){
                 goto error;
             }

--- a/owamp/owamp.h
+++ b/owamp/owamp.h
@@ -919,6 +919,7 @@ OWPSessionRequest(
         OWPBoolean      server_conf_sender,
         I2Addr          receiver,
         OWPBoolean      server_conf_receiver,
+        OWPBoolean      zero_addr,
         OWPTestSpec     *test_spec,
         FILE            *fp,
         OWPSID          sid_ret,

--- a/owamp/owampP.h
+++ b/owamp/owampP.h
@@ -632,6 +632,7 @@ _OWPEncodeTestRequestPreamble(
         OWPBoolean      server_conf_sender,
         OWPBoolean      server_conf_receiver,
         OWPBoolean      twoway,
+        OWPBoolean      zero_addr,
         OWPSID          sid,
         OWPTestSpec     *tspec
         );
@@ -672,6 +673,7 @@ _OWPWriteTestRequest(
         struct sockaddr *receiver,
         OWPBoolean      server_conf_sender,
         OWPBoolean      server_conf_receiver,
+        OWPBoolean      zero_addr,
         OWPSID          sid,
         OWPTestSpec     *test_spec
         );

--- a/owamp/protocol.c
+++ b/owamp/protocol.c
@@ -679,12 +679,18 @@ _OWPEncodeTestRequestPreamble(
         case 6:
         /* sender address  and port */
         saddr6 = (struct sockaddr_in6*)sender;
-        memcpy(&buf[16],saddr6->sin6_addr.s6_addr,16);
+        if (twoway)
+            memset(&buf[16], 0, 16);
+        else
+            memcpy(&buf[16],saddr6->sin6_addr.s6_addr,16);
         *(uint16_t*)&buf[12] = saddr6->sin6_port;
 
         /* receiver address and port  */
         saddr6 = (struct sockaddr_in6*)receiver;
-        memcpy(&buf[32],saddr6->sin6_addr.s6_addr,16);
+        if (twoway)
+            memset(&buf[32], 0, 16);
+        else
+            memcpy(&buf[32],saddr6->sin6_addr.s6_addr,16);
         *(uint16_t*)&buf[14] = saddr6->sin6_port;
 
         break;
@@ -692,13 +698,13 @@ _OWPEncodeTestRequestPreamble(
         case 4:
         /* sender address and port  */
         saddr4 = (struct sockaddr_in*)sender;
-        *(uint32_t*)&buf[16] = saddr4->sin_addr.s_addr;
+        *(uint32_t*)&buf[16] = twoway ? 0 : saddr4->sin_addr.s_addr;
         *(uint16_t*)&buf[12] = saddr4->sin_port;
         memset(&buf[20],0,12);
 
         /* receiver address and port  */
         saddr4 = (struct sockaddr_in*)receiver;
-        *(uint32_t*)&buf[32] = saddr4->sin_addr.s_addr;
+        *(uint32_t*)&buf[32] = twoway ? 0 : saddr4->sin_addr.s_addr;
         *(uint16_t*)&buf[14] = saddr4->sin_port;
         memset(&buf[36],0,12);
 

--- a/owamp/protocol.c
+++ b/owamp/protocol.c
@@ -588,6 +588,7 @@ _OWPEncodeTestRequestPreamble(
         OWPBoolean      server_conf_sender, 
         OWPBoolean      server_conf_receiver,
         OWPBoolean      twoway,
+        OWPBoolean      zero_addr,
         OWPSID          sid,
         OWPTestSpec     *tspec
         )
@@ -679,7 +680,7 @@ _OWPEncodeTestRequestPreamble(
         case 6:
         /* sender address  and port */
         saddr6 = (struct sockaddr_in6*)sender;
-        if (twoway)
+        if (zero_addr)
             memset(&buf[16], 0, 16);
         else
             memcpy(&buf[16],saddr6->sin6_addr.s6_addr,16);
@@ -687,7 +688,7 @@ _OWPEncodeTestRequestPreamble(
 
         /* receiver address and port  */
         saddr6 = (struct sockaddr_in6*)receiver;
-        if (twoway)
+        if (zero_addr)
             memset(&buf[32], 0, 16);
         else
             memcpy(&buf[32],saddr6->sin6_addr.s6_addr,16);
@@ -698,13 +699,13 @@ _OWPEncodeTestRequestPreamble(
         case 4:
         /* sender address and port  */
         saddr4 = (struct sockaddr_in*)sender;
-        *(uint32_t*)&buf[16] = twoway ? 0 : saddr4->sin_addr.s_addr;
+        *(uint32_t*)&buf[16] = zero_addr ? 0 : saddr4->sin_addr.s_addr;
         *(uint16_t*)&buf[12] = saddr4->sin_port;
         memset(&buf[20],0,12);
 
         /* receiver address and port  */
         saddr4 = (struct sockaddr_in*)receiver;
-        *(uint32_t*)&buf[32] = twoway ? 0 : saddr4->sin_addr.s_addr;
+        *(uint32_t*)&buf[32] = zero_addr ? 0 : saddr4->sin_addr.s_addr;
         *(uint16_t*)&buf[14] = saddr4->sin_port;
         memset(&buf[36],0,12);
 
@@ -1010,6 +1011,7 @@ _OWPWriteTestRequest(
         struct sockaddr *receiver,
         OWPBoolean      server_conf_sender,
         OWPBoolean      server_conf_receiver,
+        OWPBoolean      zero_addr,
         OWPSID          sid,
         OWPTestSpec     *test_spec
         )
@@ -1032,8 +1034,8 @@ _OWPWriteTestRequest(
      * the "buf" in the format required by V5 of owamp spec section 4.3.
      */
     if((_OWPEncodeTestRequestPreamble(cntrl->ctx,cntrl->msg,&buf_len,
-                    sender,receiver,server_conf_sender,
-                    server_conf_receiver,cntrl->twoway,sid,test_spec) != 0) ||
+                    sender,receiver,server_conf_sender,server_conf_receiver,
+                    cntrl->twoway,zero_addr,sid,test_spec) != 0) ||
             (buf_len != 112)){
         return OWPErrFATAL;
     }

--- a/owping/owpingP.h
+++ b/owping/owpingP.h
@@ -81,6 +81,7 @@ typedef    struct {
         char            *savedir;           /* -d */
         I2Boolean       printfiles;         /* -p */
         char            *srcaddr;           /* -S */
+        I2Boolean       zero_addr;          /* -Z */
 
         OWPPortRange    portspec;           /* -P */
 

--- a/powstream/powstream.c
+++ b/powstream/powstream.c
@@ -1141,9 +1141,9 @@ SetupSession(
      */
     tspec.start_time = *p->nextSessionStart;
     if(appctx.opt.sender){
-        if(!OWPSessionRequest(p->cntrl,NULL,(OWPBoolean)False,
-                    I2AddrByNode(eh,appctx.remote_test),(OWPBoolean)True,
-                    (OWPTestSpec*)&tspec,NULL,p->sid,&err)){
+        if(!OWPSessionRequest(p->cntrl,NULL,False,
+                    I2AddrByNode(eh,appctx.remote_test),True,
+                    False,(OWPTestSpec*)&tspec,NULL,p->sid,&err)){
             I2ErrLog(eh,"OWPSessionRequest: Failed");
             /*
             if(err == OWPErrFATAL){
@@ -1155,8 +1155,8 @@ SetupSession(
         }
     }
     else{
-        if(!OWPSessionRequest(p->cntrl,I2AddrByNode(eh,appctx.remote_test),
-                    True, NULL, False,(OWPTestSpec*)&tspec,p->testfp,
+        if(!OWPSessionRequest(p->cntrl, I2AddrByNode(eh,appctx.remote_test),
+                    True, NULL, False, False, (OWPTestSpec*)&tspec, p->testfp,
                     p->sid,&err)){
             I2ErrLog(eh,"OWPSessionRequest: Failed");
             /*

--- a/test/session_setup.c
+++ b/test/session_setup.c
@@ -221,6 +221,7 @@ int session_setup_test(
                 // not a real test, but these params run through the basic setup
                 I2AddrByNode(ctx->eh, "127.0.0.1"), True,
                 I2AddrByNode(ctx->eh, "127.0.0.1"), True,
+                False,
                 &tspec,
                 NULL,
                 sid_ret, &err_ret)) {


### PR DESCRIPTION
This pull request fixes #49 by sending zero-addresses for sender and receiver in the test session request sent by twping. The server application twampd handles this request already by using the control session addresses. This allows to use twping with a client behind a NAT and the server behind a NAT. The server's NAT must forward the TCP control port and UDP test ports to the server to make it work.

Sending zero-addresses is allowed according to [RFC 5357 section 3.5](https://tools.ietf.org/html/rfc5357#section-3.5).

The PR is marked as WIP, since with it twping will always send zero-addresses in its test session request. This might not be desired. Other possibilities would be:

- Make zero-addresses the default behaviour and provide an option to send the sender and receiver addresses as before.
- Leave the default behaviour as it was and provide an option to send zero-addresses.

Maybe some discussion about implications is required.