### PR TITLE
Fixes Issue #42:  Minor documentation changes for authenticated connections.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -54,4 +54,10 @@ To get the list of available options use:
 
 	% owping -h
 
+
+To setup local authentication, create an owamp-server.pfs file using the
+pfstore I2util command.  For more information see the owampd.pfs(5) man page:
+
+	% pfstore -f owamp-server.pfs -n [username]
+
 Problems/Questions can be reported to owamp@internet2.edu

--- a/doc/owampd.pfs.man
+++ b/doc/owampd.pfs.man
@@ -25,10 +25,10 @@
 .SH NAME
 owampd.pfs \- One-way latency server pass-phrase store
 .SH DESCRIPTION
-The \fBowampd.pfs\fR file is used to hold the identity/pass-phrase pairs
-needed for \fBowampd\fR to authenticate users. The format of this file
-is described in the pfstore(1) manual page. The location of this
-file is controlled by the \fB\-c\fR option to \fBowampd\fR.
+The \fBowampd.pfs\fR file (owamp-server.pfs by default) is used to hold the
+identity/pass-phrase pairs needed for \fBowampd\fR to authenticate users.
+The format of this file is described in the pfstore(1) manual page. The
+location of this file is controlled by the \fB\-c\fR option to \fBowampd\fR.
 .PP
 \fBowampd\fR uses symmetric AES keys for authentication. These keys
 are derived from a shared secret (the pass-phrase) using the PBKDF2


### PR DESCRIPTION
I don't believe authenticated owamp is used much (if at all), but this may help anyone else that happens to test it.  It'd be nice to change the default to "owampd.pfs" instead, but that could break existing services.