### PR TITLE
Fix test/owstats for 32bit architecture (i386)

### DIFF
--- a/test/e2e_utils.c
+++ b/test/e2e_utils.c
@@ -7,6 +7,8 @@
  *        Description:  end-to-end process utililities
  */
 
+#include <owamp/owamp.h>
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -19,7 +21,6 @@
 #include <sys/wait.h>
 #include <signal.h>
 
-#include <owamp/owamp.h>
 #include <owamp/owampP.h>
 #include <owampd/owampdP.h>
 #include <I2util/util.h>

--- a/test/owping_clear.c
+++ b/test/owping_clear.c
@@ -7,12 +7,12 @@
  *        Description:  Basic owping client control setup test
  */
 
+#include <owamp/owamp.h>
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
-
-#include <owamp/owamp.h>
 
 #include "./server.h"
 #include "./session_setup.h"

--- a/test/owping_enc.c
+++ b/test/owping_enc.c
@@ -7,12 +7,12 @@
  *        Description:  Basic owping client control setup test in encrypted/authenticated mode
  */
 
+#include <owamp/owamp.h>
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
-
-#include <owamp/owamp.h>
 
 #include "./server.h"
 #include "./session_setup.h"

--- a/test/owstats.c
+++ b/test/owstats.c
@@ -6,13 +6,14 @@
  *
  *        Description:  Basic session parsing & statistics sanity check
  */
+#include <owamp/owamp.h>
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 #include <assert.h>
 
-#include <owamp/owamp.h>
 #include <I2util/util.h>
 
 #include "./owtest_utils.h"

--- a/test/owtest_utils.c
+++ b/test/owtest_utils.c
@@ -6,6 +6,8 @@
  *
  *        Description:  shared test methods/structs
  */
+#include <owamp/owamp.h>
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -15,7 +17,6 @@
 #include <sys/un.h>
 #include <dirent.h>
 
-#include <owamp/owamp.h>
 #include <I2util/util.h>
 
 #include "./owtest_utils.h"

--- a/test/server.c
+++ b/test/server.c
@@ -6,6 +6,7 @@
  *
  *        Description:  Basic twping control server emulation
  */
+#include <owamp/owamp.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -14,7 +15,6 @@
 #include <time.h>
 #include <sys/socket.h>
 
-#include <owamp/owamp.h>
 #
 #include "./server.h"
 

--- a/test/session_setup.c
+++ b/test/session_setup.c
@@ -8,6 +8,8 @@
  *                      and setting up a control session
  */
 
+#include <owamp/owamp.h>
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -18,8 +20,6 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 
-
-#include <owamp/owamp.h>
 #include <owamp/owampP.h>
 #include <I2util/util.h>
 #include <I2util/addr.h>

--- a/test/twping_clear.c
+++ b/test/twping_clear.c
@@ -7,12 +7,12 @@
  *        Description:  Basic twping client control setup test in clear mode
  */
 
+#include <owamp/owamp.h>
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
-
-#include <owamp/owamp.h>
 
 #include "./server.h"
 #include "./session_setup.h"

--- a/test/twping_enc.c
+++ b/test/twping_enc.c
@@ -7,12 +7,12 @@
  *        Description:  Basic twping client control setup test
  */
 
+#include <owamp/owamp.h>
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
-
-#include <owamp/owamp.h>
 
 #include "./server.h"
 #include "./session_setup.h"


### PR DESCRIPTION
owamp/config.h does a #define _FILE_OFFSET_BITS 64, which changes the
size of off_t defined in fcntl.h from 4 to 8 in i386
architectures. That, in turn, changes the size of the structures in
owamp/owamp.h that have off_t members.

test/owstats was including fcntl.h before including owamp/config.h,
which made it create shorter structures in the stack. When the test
called api.c functions that had the structure with the correct size,
the stack was overrun, generating a segmentation fault.

This commit adds a #include <owamp/config.h> at the start of
test/owstats.c to fix this specific issue.