### PR TITLE
owamp: use proper adjtimex() syscall name instead of glibc ntp_adjtime() alias

### DIFF
--- a/owamp/time.c
+++ b/owamp/time.c
@@ -103,8 +103,8 @@ _OWPInitNTP(
         struct timex        ntp_conf;
 
 	memset(&ntp_conf,0,sizeof(ntp_conf));
-        if(ntp_adjtime(&ntp_conf) < 0){
-            OWPError(ctx,OWPErrFATAL,OWPErrUNKNOWN,"ntp_adjtime(): %M");
+        if(adjtimex(&ntp_conf) < 0){
+            OWPError(ctx,OWPErrFATAL,OWPErrUNKNOWN,"adjtimex(): %M");
             return 1;
         }
 
@@ -209,8 +209,8 @@ _OWPGetTimespec(
         struct timex        ntp_conf;
 
         memset(&ntp_conf,0,sizeof(ntp_conf));
-        if(ntp_adjtime(&ntp_conf) < 0){
-            OWPError(ctx,OWPErrFATAL,OWPErrUNKNOWN,"ntp_adjtime(): %M");
+        if(adjtimex(&ntp_conf) < 0){
+            OWPError(ctx,OWPErrFATAL,OWPErrUNKNOWN,"adjtimex(): %M");
             return NULL;
         }
 


### PR DESCRIPTION
the musl libc only provides the adjtimex() name, not the ntp one.  this allows the owamp code to be portable to both glibc and musl libc.