### PR TITLE
Fix buffer overflow in recvfrom()

### DIFF
--- a/owamp/endpoint.c
+++ b/owamp/endpoint.c
@@ -452,8 +452,8 @@ _OWPEndpointInit(
          * We attempt to reflect the same sized packet back, but only
          * if the sender has requested enough padding.
          */
-        snd_payload_len = MAX(snd_payload_len, OWPTestTWPayloadSize(
-                                  ep->cntrl->mode, 0));
+        snd_payload_len = MAX(snd_payload_len, ep->len_payload + OWPTestTWPayloadSize(
+                                  ep->cntrl->mode, 0) - OWPTestPayloadSize(ep->cntrl->mode,0));
     }
     /* use calloc to initialize the memory to 0 */
     ep->payload = calloc(1,MAX(ep->len_payload,snd_payload_len));


### PR DESCRIPTION
There is a potential buffer overflow in calls to recvfrom() because the `ep->payload` buffer is not over-allocated sufficiently as stated in the comment in endpoint.c. I've changed it to be allocated like how it is used. I could also be the usage that is wrong (not sure).

https://github.com/perfsonar/owamp/blob/c17e794993e1688869c7dcd3a163c7e8fbc9636d/owamp/endpoint.c#L3501-L3504

This is the length eventually passed to recvfrom() (68 bytes)

https://github.com/perfsonar/owamp/blob/c17e794993e1688869c7dcd3a163c7e8fbc9636d/owamp/endpoint.c#L3506-L3508

This is how it is allocated (41 bytes):

https://github.com/perfsonar/owamp/blob/c17e794993e1688869c7dcd3a163c7e8fbc9636d/owamp/endpoint.c#L449-L459
