### PR TITLE
debhelper 9.20160709 provides dh-systemd

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: perfSONAR developers <debian@perfsonar.net>
 Uploaders: Antoine Delvaux <antoine.delvaux@man.poznan.pl>,
  Valentin Vidic <Valentin.Vidic@CARNet.hr>
-Build-Depends: debhelper (>= 9), dh-apparmor, dh-autoreconf, dh-exec, dh-systemd, libi2util-dev (>= 1.4),
+Build-Depends: debhelper (>= 9), dh-apparmor, dh-autoreconf, dh-exec, debhelper (>= 9.20160709) | dh-systemd, libi2util-dev (>= 1.4),
  libcap-dev, libssl-dev
 Standards-Version: 3.9.8
 Homepage: http://software.internet2.edu/owamp/


### PR DESCRIPTION
dh-systemd was folded into debhelper after 9.20160709, and in Debian Bullseye
the transitional dh-systemd package was finally removed.