### PR TITLE
Subsession owp

### DIFF
--- a/owamp/owamp/.gitignore
+++ b/owamp/owamp/.gitignore
@@ -1,0 +1,8 @@
+# checkinstall stuff
+backup-*.tgz
+owamp_*.deb
+description-pak
+doc-pak*
+checkinstall-make-deb.sh
+# emacs backup files
+*~

--- a/owamp/owamp/configure.ac
+++ b/owamp/owamp/configure.ac
@@ -34,7 +34,7 @@ AC_CONFIG_SRCDIR(owamp/context.c)
 AM_CONFIG_HEADER(owamp/config.h)
 
 AC_DEFINE(PATCH_LEVEL, 1, "The RPM version number")
-AC_SUBST(PATCH_LEVEL, 0.a1.0)
+AC_SUBST(PATCH_LEVEL, 1)
  
 TOP_BUILD_DIRS=""
 

--- a/owamp/owamp/doc/powstream.man
+++ b/owamp/owamp/doc/powstream.man
@@ -87,7 +87,9 @@ is created after the Stop-Sessions message has been received from
 the sender host over the control socket. This message includes information about
 any packet records that the sender did not send; therefore, the preliminary
 data could show packet loss when, in reality, the sending process never sent
-the expected packets.
+the expected packets. The \fI\-n\fR option may be applied to make powstream
+also output data files for each sub-session defined by \fI\-N\fR. If set \fI\-n\fR
+may cause results not to take into account unsent packets.
 .PP
 .B powstream
 saves data files and summary files for each session in the current directory,
@@ -401,6 +403,17 @@ option.
 .RS
 .IP Default:
 unset
+.RE
+.TP
+\fB\-n\fR
+.br
+Enable output of sub-session data files (in addition to summary files).
+This option requires \fI\-N\fR to be set. Note that this option will
+disable output of the additional full data set summary file and full data
+file which normally is output when only \fI\-N\fR is set.
+.RS
+.IP Default:
+Unset.
 .RE
 .TP
 \fB\-p\fR

--- a/owamp/owamp/owamp/config.h.in
+++ b/owamp/owamp/owamp/config.h.in
@@ -3,6 +3,9 @@
 /* "name of sysconfdir under prefix" */
 #undef AUTOCONF_SYSCONFDIR
 
+/* Define to 1 if you have the `adjtimex' function. */
+#undef HAVE_ADJTIMEX
+
 /* Define to 1 if you have the `bind' function. */
 #undef HAVE_BIND
 
@@ -59,6 +62,9 @@
 
 /* Define to 1 if you have the <netdb.h> header file. */
 #undef HAVE_NETDB_H
+
+/* Define to 1 if you have the `ntp_adjtime' function. */
+#undef HAVE_NTP_ADJTIME
 
 /* Define to 1 if you have the `socket' function. */
 #undef HAVE_SOCKET

--- a/owamp/owamp/powstream/powstream.c
+++ b/owamp/owamp/powstream/powstream.c
@@ -764,7 +764,8 @@ write_session(
       /* Find start timestamp for beginning of current subsession */
       (void)OWPScheduleContextReset(p->sctx,NULL,NULL);
       OWPNum64 starttime_currentSubsession = p->currentSessionStartNum;
-      for( uint32_t nrecs=0; nrecs < appctx.opt.numBucketPackets*currentSubsession; nrecs++){
+      uint32_t nrecs;
+      for( nrecs=0; nrecs < appctx.opt.numBucketPackets*currentSubsession; nrecs++){
 	starttime_currentSubsession = OWPNum64Add(starttime_currentSubsession,
 						OWPScheduleContextGenerateNextDelta(p->sctx));
       }

--- a/owamp/owamp/powstream/powstream.c
+++ b/owamp/owamp/powstream/powstream.c
@@ -423,6 +423,110 @@ error_out:
 }
 
 /*
+ * Function:    write_subsession_owp
+ *
+ * Description:    
+ *              Writes raw owp data not already output by the same
+ *              function. Takes a completed session and copies it from the
+ *              unlinked file - possibly computing a new endtime
+ *              based on the last "valid" record in the file.
+ *              (Technically, it should probably be based on the
+ *              scheduled sendtime
+ *
+ * In Args: 
+ *          p            - control structure
+ *          tofd         - filedescriptor to output file
+ *          num_records  - maximum number of records to output    
+ *          
+ * Out Args:    
+ *
+ * Scope:    
+ * Returns: 
+ *      True on success, false on failure   
+ * Side Effect:
+ *      Skip records are not explicitly considered
+ */
+static int
+write_subsession_owp(
+    pow_cntrl       p,
+    int             tofd,
+    uint32_t        num_records
+    )
+{
+    OWPSessionHeaderRec hdr;
+    unsigned char *owpheaderbuffer = NULL;
+    unsigned char *owprecordbuffer = NULL;
+    long current_subsessionowp_pos = ftell(p->subsessionowp_fp);
+    
+    
+    // Get hold of relevant sizes and offsets
+    (void)OWPReadDataHeader(p->ctx,p->fp,&hdr); 
+    
+    // Fetch copy of header
+    if(fseeko(p->subsessionowp_fp,0,SEEK_SET) != 0){
+	I2ErrLog(eh,"write_subsession_owp: fseeko() %M");
+	return False;
+    }
+    int hdr_len = hdr.oset_datarecs;  // Header = All bytes before datarecords start
+    owpheaderbuffer = calloc(hdr_len, 1);
+    int bytesread;
+    if ((bytesread = fread( owpheaderbuffer, 1, hdr_len, p->subsessionowp_fp)) != hdr_len) {
+	I2ErrLog(eh,"write_subsession_owp: fread() failed reading header %d .", bytesread);
+	return False;
+    }
+    // Write copy of header to output file.
+    if (write(tofd, owpheaderbuffer, hdr_len) != hdr_len ) {
+	OWPError(p->ctx,OWPErrFATAL,errno,"write_subsession_owp: write() %M");
+	return False;
+    }
+    if (current_subsessionowp_pos > 0) {
+	// Move file pointer back to current relevant data record
+	if(fseeko(p->subsessionowp_fp,current_subsessionowp_pos,SEEK_SET) != 0){
+	    I2ErrLog(eh,"write_subsession_owp: fseeko() %M");
+	    return False;
+	}
+    }
+    // Include rest of subsession records
+    uint32_t subsessionowprecords_to_output = num_records;
+    current_subsessionowp_pos = ftell(p->subsessionowp_fp);
+    owprecordbuffer = calloc(hdr.rec_size,1);
+    while ( subsessionowprecords_to_output > 0 && fread(owprecordbuffer, 1, hdr.rec_size, p->subsessionowp_fp) == hdr.rec_size) {
+	// OWP record read successfully. Output.
+	if (write(tofd, owprecordbuffer, hdr.rec_size) != hdr.rec_size ) {
+	    OWPError(p->ctx,OWPErrFATAL,errno,  "write_subsession_owp: write() %M");
+	    return False;
+	}
+	subsessionowprecords_to_output--;
+	current_subsessionowp_pos = ftell(p->subsessionowp_fp);
+    }
+    if (subsessionowprecords_to_output > 0) {
+	// Set input file pointer to beginning of record since not all expected records where output)
+	if(fseeko(p->subsessionowp_fp, current_subsessionowp_pos, SEEK_SET) != 0){
+	    I2ErrLog(eh,"write_subsession_owp: fseeko() %M");
+	    return False;
+	}
+    }
+    // Update Num of records field in header
+    uint32_t num_rec_field = num_records - subsessionowprecords_to_output;
+    if(lseek(tofd, 20, SEEK_SET)<0){
+	OWPError(p->ctx,OWPErrFATAL,errno,  "write_subsession_owp: write() %M");
+	return False;
+    }
+    num_rec_field = htonl(num_rec_field);
+    if (write(tofd, &num_rec_field, sizeof(uint32_t)) != sizeof(uint32_t) ) {
+	OWPError(p->ctx,OWPErrFATAL,errno,  "write_subsession_owp: write() %M");
+	return False;
+    }
+    
+    // Clean up buffers
+    if(owpheaderbuffer) free(owpheaderbuffer);
+    if(owprecordbuffer) free(owprecordbuffer);
+    
+    return True;
+}
+
+
+/*
  * Function:    write_session
  *
  * Description:    
@@ -493,6 +597,15 @@ write_session(
             return;
         }
 
+	//
+	// Move subsessionowp data dump ("-n") read-only file
+	// pointer to beginning also due to above trunc
+	//
+	if(fseeko(p->subsessionowp_fp,0,SEEK_SET) != 0){
+	  I2ErrLog(eh,"fseeko(): %M");
+	  return;
+	}
+	
         /*
          * Fetch the data and put it in testfp
          */
@@ -706,31 +819,36 @@ write_session(
     }
     dotf=True;
 
+    
     /*
      * stat the "from" file, ftruncate the to file,
      * mmap both of them, then do a memcpy between them.
      */
 
+    // .. or write out rest of data not already writting in
+    // earlier subsessions
     
-    if(I2CopyFile(eh,tofd,fileno(p->fp),0) == 0){
-        /*
-         * Relink the incomplete file as a complete one.
-         */
-        strcpy(ofname,tfname);
-        sprintf(&ofname[ext_offset],"%s",OWP_FILE_EXT);
-        if(link(tfname,ofname) != 0){
-            /* note, but ignore the error */
-            I2ErrLog(eh,"link(%s,%s): %M",tfname,ofname);
-            ofname[0]='\0';
-        }
+    //if(I2CopyFile(eh,tofd,fileno(p->fp),0) == 0){
+    if(appctx.opt.subsessionowp && write_subsession_owp(p,tofd, 0xFFFFFFFF) ||
+       I2CopyFile(eh,tofd,fileno(p->fp),0) == 0){
+      /*
+       * Relink the incomplete file as a complete one.
+       */
+      strcpy(ofname,tfname);
+      sprintf(&ofname[ext_offset],"%s",OWP_FILE_EXT);
+      if(link(tfname,ofname) != 0){
+	/* note, but ignore the error */
+	I2ErrLog(eh,"link(%s,%s): %M",tfname,ofname);
+	ofname[0]='\0';
+      }
     }
 
 skip_data:
-
+    
     while((close(tofd) != 0) && errno==EINTR);
     if(dotf && (unlink(tfname) != 0)){
-        /* note, but ignore the error */
-        I2ErrLog(eh,"unlink(%s): %M",tfname);
+      /* note, but ignore the error */
+      I2ErrLog(eh,"unlink(%s): %M",tfname);
     }
     dotf=False;
 
@@ -1293,6 +1411,9 @@ fetch_clean:
     return -1;
 }
 
+
+
+
 int
 main(
         int     argc,
@@ -1758,6 +1879,14 @@ main(
         }
     }
 
+    // Check if "-n" also has "-N" set
+    if(appctx.opt.subsessionowp &&  ! appctx.opt.numBucketPackets ) {
+      usage(progname,
+	    "Option -n requires option -N to be set (>0).");
+      exit(1);
+    }
+
+    
     /*
      * Add time for file buffering. 
      * Add 2 seconds to the max of (1,mu). file io is optimized to
@@ -1944,14 +2073,6 @@ wait_again:
         }
 
 
-	//FILE *subsessionowp_fp = fdopen(dup (fileno(p->fp)), "r"); 
-	// Move handle past headers
-	//if(fseeko(subsessionowp_fp, hdr->oset_datarecs ,SEEK_SET) != 0){
-	//  OWPError(ctx,OWPErrFATAL,errno,
-	//	   "main: fseeko(): %M");
-	//  return False;
-	//}
-	
         for(sum=0;sum<numSummaries;sum++){
             uint32_t            nrecs;
             OWPSessionHeaderRec hdr;
@@ -2081,23 +2202,15 @@ AGAIN:
                     break;
                 }
 
-                /*
-                 * Move subsessionowp data dump ("-n") read-only file pointer to beginning also due to above trunc
-                 */
-               if(fseeko(p->subsessionowp_fp,0,SEEK_SET) != 0){
-                    I2ErrLog(eh,"fseeko(): %M");
-                    break;
+                //
+                // Move subsessionowp data dump ("-n") read-only file
+		// pointer to beginning also due to above trunc
+                //
+		if(fseeko(p->subsessionowp_fp,0,SEEK_SET) != 0){
+		  I2ErrLog(eh,"fseeko(): %M");
+		  break;
                 }
- 		
 
-		// Move handle past headers
-		//if(fseeko(subsessionowp_fp, hdr->oset_datarecs ,SEEK_SET) != 0){
-		//  OWPError(ctx,OWPErrFATAL,errno,
-		//	   "main: fseeko(): %M");
-		//  return False;
-		//}
-
-		
                 /*
                  * Fetch the data and put it in testfp
                  */
@@ -2125,15 +2238,9 @@ AGAIN:
             }
 
 	    if(appctx.opt.subsessionowp) {
-	      /* 
-	       * Output raw owp data for this subsession 
-	       */
-	      if ( ! appctx.opt.numBucketPackets ) {
-                    usage(progname,
-                            "Option -n requires option -N to be set (>0).");
-                    exit(1);
-	      }
-
+	      // 
+	      // Output raw owp data for this subsession 
+	      //
 	    
 	      char     ofname[PATH_MAX];
 	      int      tofd = -1;
@@ -2189,160 +2296,33 @@ AGAIN:
 	      }
 	      dotf=True;
 
-	      /*
-	      FILE* dumpfp = fopen("dump.owp","w");
-	      unsigned char dumpbuf[256];
-	      size_t dumpread;
-	      while ((dumpread = fread(dumpbuf, 1, 256, p->subsessionowp_fp)) > 0 )
-		fwrite(dumpbuf,1,dumpread,dumpfp);
-	      fclose(dumpfp);
-	      fseeko(p->subsessionowp_fp,0,SEEK_SET);
-	      */
+	      	      
+	      ///*
+	      // * stat the "from" file, ftruncate the to file,
+	      // * mmap both of them, then do a memcpy between them.
+	      // */
+	      //if(I2CopyFile(eh,tofd,fileno(p->fp),0) == 0){
 	      
-	      // Copy received raw owp data since last subsession
-	      (void)OWPReadDataHeader(ctx,p->fp,&hdr);   // ... to get hold relevant of sizes and offsets
-	      unsigned char *owpheaderbuffer = NULL;
-	      unsigned char *owprecordbuffer = NULL;
-	      long current_subsessionowp_pos = ftell(p->subsessionowp_fp);
-	      //printf("Input pos: %ld\n", ftell(p->subsessionowp_fp));
-	      // Fetch copy of header
-	      if(fseeko(p->subsessionowp_fp,0,SEEK_SET) != 0){
-		I2ErrLog(eh,"fseeko(): %M");
-		return False;
-	      }
-	      int hdr_len = hdr.oset_datarecs;  // Header = All bytes before datarecords start
-	      owpheaderbuffer = calloc(hdr_len, 1);
-	      int bytesread;
-	      if ((bytesread = fread( owpheaderbuffer, 1, hdr_len, p->subsessionowp_fp)) != hdr_len) {
-		I2ErrLog(eh,"fread() failed reading header %d .", bytesread);
-		return False;
-	      }
-	      //printf("Header read (%d)\n", hdr_len);
-	      // Write copy of header to output file.
-	      if (write(tofd, owpheaderbuffer, hdr_len) != hdr_len ) {
-		OWPError(ctx,OWPErrFATAL,errno,"main: write(): %M");
-		return False;
-	      }
-	      //printf("Header written (%d).\n", hdr_len);
-	      //printf("Input pos: %ld\n", ftell(p->subsessionowp_fp));
-	      if (current_subsessionowp_pos > 0) {
-		// Move file pointer back to current relevant data record
-		if(fseeko(p->subsessionowp_fp,current_subsessionowp_pos,SEEK_SET) != 0){
-		  I2ErrLog(eh,"fseeko(): %M");
-		  return False;
-		}
-		//printf("File pointer moved (%ld).\n", current_subsessionowp_pos );
-	      }
-	      // Include rest of subsession records
-	      uint32_t subsessionowprecords_to_output = appctx.opt.numBucketPackets;
-	      current_subsessionowp_pos = ftell(p->subsessionowp_fp);
-	      owprecordbuffer = calloc(hdr.rec_size,1);
-	      //printf("no bytes per session: %d (%d)\n", subsessionowp_bytes, ftell(p->subsessionowp_fp));
-	      while ( subsessionowprecords_to_output > 0 && fread(owprecordbuffer, 1, hdr.rec_size, p->subsessionowp_fp) == hdr.rec_size) {
-		// OWP record read successfully. Output.
-		//printf("Record read (%d, %d)\n", subsessionowprecords_to_output, hdr.rec_size);
-		if (write(tofd, owprecordbuffer, hdr.rec_size) != hdr.rec_size ) {
-		  OWPError(ctx,OWPErrFATAL,errno,  "main: write(): %M");
-		  return False;
-		}
-		//printf("Record written.\n");
-		subsessionowprecords_to_output--;
-		current_subsessionowp_pos = ftell(p->subsessionowp_fp);
-		//printf("Input pos: %ld\n", ftell(p->subsessionowp_fp));
-	      }
-	      if (subsessionowprecords_to_output > 0) {
-		// Set input file pointer to beginning of record since not all expected records where output)
-		if(fseeko(p->subsessionowp_fp, current_subsessionowp_pos, SEEK_SET) != 0){
-		  I2ErrLog(eh,"fseeko(): %M");
-		  return False;
-		}
-	      }
-	      // Update Num of records field
-	      printf("Num recs: %d\n", appctx.opt.numBucketPackets - subsessionowprecords_to_output);
-	      FILE* tofp = fdopen(tofd,"r+");
-	      OWPWriteDataHeaderNumDataRecs(ctx, tofp, appctx.opt.numBucketPackets - subsessionowprecords_to_output );
-	      fflush(tofp);
-	      /*
-	      if( hdr.version == 3) {
-		// Version 3 header: Update Num of records field
-		owpheaderbuffer[20] = htonl(appctx.opt.numBucketPackets - subsessionowprecords_to_output);
-		// Rewrite header
-		if(lseek(tofd, 0, SEEK_SET)) {
-		  OWPError(ctx,OWPErrFATAL,errno,  "main: lseek(): %M");
-		  return False;
-		}
-		if (write(tofd, owpheaderbuffer, hdr_len) != hdr_len ) {
-		  OWPError(ctx,OWPErrFATAL,errno,"main: write(): %M");
-		  return False;
-		}
-	      }	
-	      */
-	      
-	      // Clean up buffers
-	      if(owpheaderbuffer) free(owpheaderbuffer);
-	      if(owprecordbuffer) free(owprecordbuffer);
+	      // Output received raw owp data since last subsession
+	      if (write_subsession_owp(p,tofd, appctx.opt.numBucketPackets)) {
 	
-	      
-	      /*
-	       * stat the "from" file, ftruncate the to file,
-	       * mmap both of them, then do a memcpy between them.
-	       */
-
-	      /*** DISABLED CODE *
-	      // Find end of pck records in file
-	      off_t       fileend;
-	      uint32_t    nrecs;
-	      if(hdr->oset_skiprecs > hdr->oset_datarecs){
-		fileend = stats->hdr->oset_skiprecs;
-	      } else {
-		if(fseeko(fromfd,0,SEEK_END) != 0){
-		  OWPError(ctx,OWPErrFATAL,errno,
-			   "main: fseeko(): %M");
-		  return False;
-		}
-		if((fileend = ftello(fromfd)) < 0){
-		  OWPError(ctx,OWPErrFATAL,errno,
-			   "main: ftello(): %M");
-		  return False;
-		}
-	      }
-	      // Find first pck record in last subsession
-	      off_t  filebegin = fileend - hdr->rec_size * appctx.opt.numBucketPackets; 
-	      if(filebegin < hdr->oset_datarecs){
-		filebegin = hdr->oset_datarecs;
-	      }
-	      // Copy records for last subsession to output file
-	      if(fseeko(fromfd,filebegin,SEEK_SET) != 0){
-		OWPError(ctx,OWPErrFATAL,errno,
-			 "main: fseeko(): %M");
-		return False;
-	      }
-
-	      if(fseeko(fromfd, ????? ,SEEK_SET) != 0){
-		I2ErrLog(eh,"fseeko(): %M");
-		return;
-	      }
-	      *** END DISABLED CODE ***/
-
-	      
-	      //	      if(I2CopyFile(eh,tofd,fileno(p->fp),0) == 0){
 		/*
 		 * Relink the incomplete file as a complete one.
 		 */
-	      strcpy(ofname,tfname);
-	      sprintf(&ofname[ext_offset],"%s",OWP_FILE_EXT);
-	      if(link(tfname,ofname) != 0){
-		/* note, but ignore the error */
-		I2ErrLog(eh,"link(%s,%s): %M",tfname,ofname);
-		ofname[0]='\0';
+		strcpy(ofname,tfname);
+		sprintf(&ofname[ext_offset],"%s",OWP_FILE_EXT);
+		if(link(tfname,ofname) != 0){
+		  /* note, but ignore the error */
+		  I2ErrLog(eh,"link(%s,%s): %M",tfname,ofname);
+		  ofname[0]='\0';
+		}
+		
+		if(appctx.opt.printfiles){
+		  /* Print the filename to stdout */
+		  fprintf(stdout,"%s\n",ofname);
+		  fflush(stdout);
+		}
 	      }
-
-	      if(appctx.opt.printfiles){
-		/* Print the filename to stdout */
-		fprintf(stdout,"%s\n",ofname);
-		fflush(stdout);
-	      }
-	      //}
 
 skip_data:
 	      while((close(tofd) != 0) && errno==EINTR);

--- a/owamp/owamp/powstream/powstream.c
+++ b/owamp/owamp/powstream/powstream.c
@@ -427,11 +427,7 @@ error_out:
  *
  * Description:    
  *              Writes raw owp data not already output by the same
- *              function. Takes a completed session and copies it from the
- *              unlinked file - possibly computing a new endtime
- *              based on the last "valid" record in the file.
- *              (Technically, it should probably be based on the
- *              scheduled sendtime
+ *              function. 
  *
  * In Args: 
  *          p            - control structure
@@ -572,6 +568,17 @@ write_session(
     if(!p->fp || !p->session_started || (aval != OWP_CNTRL_ACCEPT))
         return;
 
+    uint32_t fetch_first = 0;
+    uint32_t fetch_last = 0xFFFFFFFF;
+	
+    if(appctx.opt.subsessionowp) {
+	/* Fetch only last completed subsession as ealier data has already been output */
+	fetch_first = appctx.opt.numBucketPackets * currentSubsession;
+	if (fetch_first >= appctx.opt.numPackets)
+	    // All packets have already been fetched.
+	    return;
+    }
+    
     /*
      * If sender session - data needs to be fetched from the remote server.
      */
@@ -609,17 +616,6 @@ write_session(
         /*
          * Fetch the data and put it in testfp
          */
-	uint32_t fetch_first = 0;
-	uint32_t fetch_last = 0xFFFFFFFF;
-	
-	if(appctx.opt.subsessionowp) {
-	  /* Fetch only last completed subsession as ealier data has already been output */
-	  fetch_first = appctx.opt.numBucketPackets * currentSubsession;
-	  if (fetch_first >= appctx.opt.numPackets)
-	    // All packets have already been fetched.
-	    return;
-	} 
-	// num_rec = FetchSession(p,0,(uint32_t)0xFFFFFFFF,&ec);
 	num_rec = FetchSession(p,fetch_first,fetch_last,&ec);
 
         if(!num_rec){
@@ -759,8 +755,6 @@ write_session(
     /*
      * Make a temporary session filename to hold data.
      */
-<<<<<<< HEAD
-=======
     
     if(appctx.opt.subsessionowp) {
       /* Find start timestamp for beginning of current subsession */
@@ -774,9 +768,8 @@ write_session(
       startnum = starttime_currentSubsession;
     }
 
->>>>>>> 504a65d (Powstream with -n option operative, but only when -t is set...)
     strcpy(tfname,dirpath);
-    sprintf(startname,OWP_TSTAMPFMT,p->currentSessionStartNum);
+    sprintf(startname,OWP_TSTAMPFMT,startnum);
     sprintf(endname,OWP_TSTAMPFMT,endnum);
     sprintf(&tfname[file_offset],"%s%s%s%s%s",
             startname,OWP_NAME_SEP,endname,
@@ -828,7 +821,6 @@ write_session(
     // .. or write out rest of data not already writting in
     // earlier subsessions
     
-    //if(I2CopyFile(eh,tofd,fileno(p->fp),0) == 0){
     if(appctx.opt.subsessionowp && write_subsession_owp(p,tofd, 0xFFFFFFFF) ||
        I2CopyFile(eh,tofd,fileno(p->fp),0) == 0){
       /*
@@ -873,16 +865,20 @@ skip_data:
     /*
      * Parse the data and compute the statistics
      */
-    if( !OWPStatsParse(stats,NULL,0,0,~0)){
-        I2ErrLog(eh,"OWPStatsParse failed");
-        goto skip_sum;
+    if( !OWPStatsParse(stats,NULL,stats->next_oset,fetch_first,~0)){
+	I2ErrLog(eh,"OWPStatsParse failed");
+	goto skip_sum;
     }
 
     /*
      * Make a temporary session filename to hold data.
      */
     strcpy(tfname,dirpath);
+<<<<<<< HEAD
     sprintf(startname,OWP_TSTAMPFMT,p->currentSessionStartNum);
+=======
+    sprintf(startname,OWP_TSTAMPFMT,startnum);
+>>>>>>> b88269b (Final fix to ensure consistent '-n'-behavior with and without '-t')
     sprintf(endname,OWP_TSTAMPFMT,endnum);
     sprintf(&tfname[file_offset],"%s%s%s%s%s",
             startname,OWP_NAME_SEP,endname,
@@ -2296,13 +2292,6 @@ AGAIN:
 	      }
 	      dotf=True;
 
-	      	      
-	      ///*
-	      // * stat the "from" file, ftruncate the to file,
-	      // * mmap both of them, then do a memcpy between them.
-	      // */
-	      //if(I2CopyFile(eh,tofd,fileno(p->fp),0) == 0){
-	      
 	      // Output received raw owp data since last subsession
 	      if (write_subsession_owp(p,tofd, appctx.opt.numBucketPackets)) {
 	

--- a/owamp/owamp/powstream/powstreamP.h
+++ b/owamp/owamp/powstream/powstreamP.h
@@ -121,6 +121,7 @@ typedef struct pow_cntrl_rec{
 
     FILE                *fp;
     FILE                *testfp;
+    FILE                *subsessionowp_fp;
     char                fname[PATH_MAX];
     uint32_t           numPackets;
     OWPBoolean          call_stop;


### PR DESCRIPTION


A '-n' option has been added which enables output of .owp raw data also during sub-session outputs, i.e. when '-N' is set. In addition to outputting several .owp-files per session, the last .owp and .sum files are ensured to only treat record not yet treated (and output as .owp and .sum in earlier sub-sessions). This is contrary to normal behavior for '-N' where a final pair of .owp and .sum files cover the whole session dataset. (Hence the final .sum-file re-analyses data already analysed by sub-session .sum-files.)
Note that in cases where "skip records" exists in a session '-n' may result in inaccurate output data. A warning about this has been added in the powstream man page.
